### PR TITLE
Various fixes and improvements

### DIFF
--- a/digimon/data.py
+++ b/digimon/data.py
@@ -788,3 +788,35 @@ typeEffectivenessOffset = 0x14D669F8
 learnMoveAndCommandFormat = "<II"
 learnMoveAndCommandValue  = ( 0x10000065, 0x00001021 )
 learnMoveAndCommandOffset = 0x14C8821C
+
+#DV Chip text patch
+
+DVChipAValue = "Boosts Off+Brains by 100"
+DVChipAOffset = 0x14D65F10
+DVChipAFormat = "<28s"
+
+DVChipDValue = "Boosts Def+Speed by 100"
+DVChipDOffset = 0x14D65F2C
+DVChipDFormat = "<28s"
+
+DVChipEValue = "Boosts HP+MP by 1000"
+DVChipEOffset = 0x14D65F48
+DVChipEFormat = "<28s"
+
+# Change Dragon Eye Lake Vending Machine to HappyShroom
+happyMushroomVendingOffset1 = 0x13FE31C8
+happyMushroomVendingFormat1 = "<124s"
+happyMushroomVendingValue1 = "HappyMushroom: 2000 bits\r\0DigiMushroom: 600 bits\r\0Don「t buy\r\0"
+
+happyMushroomVendingOffset2 = 0x13FE3300
+happyMushroomVendingFormat2 = "<36s"
+happyMushroomVendingValue2 = "\1\6HappyMushroom \1\1came out!\0\r\0\r\0\r"
+
+happyMushroomVendingOffset3 = 0x13FE3252
+happyMushroomVendingOffset4 = 0x13FE32F8
+happyMushroomVendingPriceFormat = "<H"
+happyMushroomVendingPriceValue = 2000
+
+happyMushroomVendingOffset5 = ( 0x13FE3326, 0x13FE3338, 0x13FE3382 )
+happyMushroomVendingFormat5 = "B"
+happyMushroomVendingValue5 = 69

--- a/digimon/data.py
+++ b/digimon/data.py
@@ -783,3 +783,8 @@ starterStatChkDigimonOffset = 0x1407E2C5
 #type effectiveness 
 typeEffectivenessFormat = 'B'
 typeEffectivenessOffset = 0x14D669F8
+ 
+#learn move and command patch
+learnMoveAndCommandFormat = "<II"
+learnMoveAndCommandValue  = ( 0x10000065, 0x00001021 )
+learnMoveAndCommandOffset = 0x14C8821C

--- a/digimon/data.py
+++ b/digimon/data.py
@@ -725,7 +725,12 @@ fixMoveToSLOffset        = ( 0x14CDB140, 0x14CDB19C )
 #Fix Toy Town softlock
 fixToyTownSLFormat       = ">I"
 fixToyTownSLValue        = 0x31FCA302
-fixToyTownSLOffset       = ( 0x14049DD8, 0x1404A2EA, )
+fixToyTownSLOffset       = ( 0x14049DD8, 0x1404A2EA )
+
+#Fix Leomon's Cave Nanimon softlock
+fixLeoCaveSLFormat       = "B"
+fixLeoCaveSLValue        = 0x3B
+fixLeoCaveSLOffset       = ( 0x14030380, 0x14030444, 0x14030D36, 0x14030DFA, 0x140317F6, 0x140318BA, 0x140321C8, 0x1403228C )
 
 #Unify evolution target function to free memory
 evoTargetUnifyHackFormat = '<I'
@@ -775,3 +780,6 @@ starterLearnTechOffset   = ( 0x14CD1D40, 0x14CD1D60 )   #tech to learn
 starterEquipAnimOffset   = ( 0x14CD1D30, 0x14CD1D50 )   #animation to equip
 starterStatChkDigimonOffset = 0x1407E2C5
 
+#type effectiveness 
+typeEffectivenessFormat = 'B'
+typeEffectivenessOffset = 0x14D669F8

--- a/digimon/handler.py
+++ b/digimon/handler.py
@@ -1229,6 +1229,8 @@ class DigimonWorldHandler:
                     self._applyPatchOgremonSoftlock( file )
                 elif( patch == 'softlock' ):
                     self._applyPatchMovementSoftlock( file )
+                elif( patch == 'typeEffectiveness'):
+                    self._randomizeTypeEffectiveness( file ) 
 
 
             #------------------------------------------------------
@@ -2681,8 +2683,14 @@ class DigimonWorldHandler:
                                   ofst,
                                   struct.pack( data.fixToyTownSLFormat, data.fixToyTownSLValue ),
                                   self.logger )
+                                  
+        for ofst in data.fixLeoCaveSLOffset:
+            util.writeDataToFile( file,
+                                  ofst,
+                                  struct.pack( data.fixLeoCaveSLFormat, data.fixLeoCaveSLValue ),
+                                  self.logger )
         
-        self.logger.logChange( "Applied 3 movement softlock patches." )
+        self.logger.logChange( "Applied 4 movement softlock patches." )
         
     def _applyPatchUnifyEvoTargetFunction( self, file ):
         """
@@ -2713,3 +2721,26 @@ class DigimonWorldHandler:
                               self.logger )
         
         self.logger.logChange( "Added custom function and hook for it" )
+
+    def _randomizeTypeEffectiveness( self, file ):
+        """
+        Randomizes type effectiveness to a random value between 2 and 20
+        """
+
+        self.logger.logChange( "Changing type effectivness chart" )
+
+        for type1 in range(0, 7):
+            row = ""
+            
+            for type2 in range(0, 7):
+                newValue = random.randint(2, 20)
+                offset =  type1 * 7 + type2
+                util.writeDataToFile( file,
+                                      data.typeEffectivenessOffset + offset,
+                                      struct.pack( data.typeEffectivenessFormat, newValue),
+                                      self.logger )
+                row = row + str(newValue) + " "
+            
+            self.logger.logChange( row )
+        
+        self.logger.logChange( "Randomized type effectiveness" )

--- a/digimon/handler.py
+++ b/digimon/handler.py
@@ -1231,6 +1231,8 @@ class DigimonWorldHandler:
                     self._applyPatchMovementSoftlock( file )
                 elif( patch == 'typeEffectiveness'):
                     self._randomizeTypeEffectiveness( file ) 
+                elif( patch == 'learnmoveandcommand'):
+                    self._applyPatchLearnMoveAndCommand( file) 
 
 
             #------------------------------------------------------
@@ -2744,3 +2746,16 @@ class DigimonWorldHandler:
             self.logger.logChange( row )
         
         self.logger.logChange( "Randomized type effectiveness" )
+
+    def _applyPatchLearnMoveAndCommand( self, file ):
+        """
+        Removes the command learning text to allow learning a move and a command
+        in the same training session.
+        """
+
+        util.writeDataToFile(   file,
+                                data.learnMoveAndCommandOffset,
+                                struct.pack( data.learnMoveAndCommandFormat, *data.learnMoveAndCommandValue ),
+                                self.logger )
+
+        self.logger.logChange( "Fixing move learning at brains training.")

--- a/digimon/handler.py
+++ b/digimon/handler.py
@@ -1232,7 +1232,11 @@ class DigimonWorldHandler:
                 elif( patch == 'typeEffectiveness'):
                     self._randomizeTypeEffectiveness( file ) 
                 elif( patch == 'learnmoveandcommand'):
-                    self._applyPatchLearnMoveAndCommand( file) 
+                    self._applyPatchLearnMoveAndCommand( file )
+                elif( patch == 'fixDVChips'):
+                    self._applyPatchDVChipDescription( file )
+                elif( patch == 'happyVending'):
+                    self._applyPatchGuaranteeHappyShrm( file )
 
 
             #------------------------------------------------------
@@ -2759,3 +2763,50 @@ class DigimonWorldHandler:
                                 self.logger )
 
         self.logger.logChange( "Fixing move learning at brains training.")
+
+    def _applyPatchDVChipDescription( self, file ):
+        """
+        Fixes the description of DV Chips to reflect what they're actually doing.
+        """
+
+        util.writeDataToFile( file,
+                              data.DVChipAOffset,
+                              struct.pack( data.DVChipAFormat, data.DVChipAValue[ :26 ].encode( 'ascii' ) ),
+                              self.logger )
+
+        util.writeDataToFile( file,
+                              data.DVChipDOffset,
+                              struct.pack( data.DVChipDFormat, data.DVChipDValue[ :26 ].encode( 'ascii' ) ),
+                              self.logger )
+
+        util.writeDataToFile( file,
+                              data.DVChipEOffset,
+                              struct.pack( data.DVChipEFormat, data.DVChipEValue[ :26 ].encode( 'ascii' ) ),
+                              self.logger )
+
+    def _applyPatchGuaranteeHappyShrm( self, file ):
+        util.writeDataToFile( file,
+                              data.happyMushroomVendingOffset1,
+                              struct.pack( data.happyMushroomVendingFormat1, data.happyMushroomVendingValue1.encode( 'shift_jis' ) ),
+                              self.logger )
+
+        util.writeDataToFile( file,
+                              data.happyMushroomVendingOffset2,
+                              struct.pack( data.happyMushroomVendingFormat2, data.happyMushroomVendingValue2.encode( 'ascii' ) ),
+                              self.logger )
+
+        util.writeDataToFile( file,
+                              data.happyMushroomVendingOffset3,
+                              struct.pack( data.happyMushroomVendingPriceFormat, data.happyMushroomVendingPriceValue ),
+                              self.logger )
+
+        util.writeDataToFile( file,
+                              data.happyMushroomVendingOffset4,
+                              struct.pack( data.happyMushroomVendingPriceFormat, data.happyMushroomVendingPriceValue ),
+                              self.logger )
+
+        for ofst in data.happyMushroomVendingOffset5:
+            util.writeDataToFile( file,
+                                  ofst,
+                                  struct.pack( data.happyMushroomVendingFormat5, data.happyMushroomVendingValue5 ),
+                                  self.logger )

--- a/digimon_randomize.py
+++ b/digimon_randomize.py
@@ -83,6 +83,9 @@ if( config[ 'techs' ][ 'Enabled' ] ):
                                accuracy=config[ 'techs' ][ 'Accuracy' ],
                                effect=config[ 'techs' ][ 'Effect' ],
                                effectChance=config[ 'techs' ][ 'EffectChance' ] )
+    
+    if( config[ 'techs' ][ 'TypeEffectiveness']):
+        handler.applyPatch( 'typeEffectiveness' )
 
 if( config[ 'starter' ][ 'Enabled' ] ):
     #Use true/false values as a mask against the list of levels

--- a/digimon_randomize.py
+++ b/digimon_randomize.py
@@ -178,14 +178,19 @@ if( config[ 'patches' ][ 'Enabled' ] ):
     if( config[ 'patches' ][ 'LearnMoveAndCommand' ] ):
         handler.applyPatch( 'learnmoveandcommand' )
 
+    if( config[ 'patches' ][ 'FixDVChips' ] ):
+        handler.applyPatch( 'fixDVChips' )
+
+    if( config[ 'patches' ][ 'HappyVending' ] ):
+        handler.applyPatch( 'happyVending' )
 
 print( 'Writing to ' + outFile + '...' )
 sys.stdout.flush()
 
 try:
     handler.write( outFile )
-except:
-    logger.logError( 'System error' )
+except Exception as ex:
+    logger.logError( 'System error: {0}'.format(ex) )
     print( 'An irrecoverable error occured' )
 
 if( not logger.error ):

--- a/digimon_randomize.py
+++ b/digimon_randomize.py
@@ -174,6 +174,9 @@ if( config[ 'patches' ][ 'Enabled' ] ):
 
     if( config[ 'patches' ][ 'Softlock' ] ):
         handler.applyPatch( 'softlock' )
+        
+    if( config[ 'patches' ][ 'LearnMoveAndCommand' ] ):
+        handler.applyPatch( 'learnmoveandcommand' )
 
 
 print( 'Writing to ' + outFile + '...' )

--- a/gui/main.css
+++ b/gui/main.css
@@ -210,14 +210,14 @@ h1.category {
 /* Special styling */
 #misc-patches {
     flex-wrap: wrap;
-    height: 140px;
+    height: 200px;
 }
 
 /* Terminal Styling */
 .terminalOutput {
     position: fixed;
     border: 3px solid rgb(38, 99, 143);
-    height: 130px;
+    height: 160px;
     width: 100%;
     background-color: black;
     color: white;

--- a/gui/src/ElementContainer.tsx
+++ b/gui/src/ElementContainer.tsx
@@ -52,7 +52,7 @@ export default function ElementContainer( props: Props ) {
             break
 
         case InputVariation.Slider:
-            const stepSize = props.maxVal / 20
+            const stepSize = props.maxVal / 100
             input = <Slider
                         className="element slider"
                         disabled={!props.enabled}

--- a/gui/src/MainModel.ts
+++ b/gui/src/MainModel.ts
@@ -107,6 +107,7 @@ export const ItemValueMax = 10000
 export const ItemValueMin = 0
 export const SpawnRateMax = 100
 export const SpawnRateMin = 1
+export const SpawnRateDefault = 3
 
 export class MainModel {
     constructor( raw?: string ) {
@@ -188,7 +189,7 @@ export class MainModel {
             JukeboxGlitch       : false,
             IncreaseLearnChance : false,
             SpawnRateEnabled    : false,
-            SpawnRate           : SpawnRateMin,
+            SpawnRate           : SpawnRateDefault,
             ShowHashIntro       : false,
             SkipIntro           : false,
             Woah                : false,

--- a/gui/src/MainModel.ts
+++ b/gui/src/MainModel.ts
@@ -100,6 +100,8 @@ export interface PatchSettings extends Toggleable {
     UnlockAreas         : boolean
     UnrigSlots          : boolean
     LearnMoveAndCommand : boolean
+    FixDVChips          : boolean
+    HappyVending        : boolean
 }
 
 /* Public Constants */
@@ -198,6 +200,8 @@ export class MainModel {
             UnlockAreas         : false,
             UnrigSlots          : false,
             LearnMoveAndCommand : false,
+            FixDVChips          : false,
+            HappyVending        : false,
         }
 
         if( raw ) {

--- a/gui/src/MainModel.ts
+++ b/gui/src/MainModel.ts
@@ -45,6 +45,7 @@ export interface TechSettings extends Toggleable {
     Accuracy            : boolean
     Effect              : boolean
     EffectChance        : boolean
+    TypeEffectiveness   : boolean
 }
 
 export interface StarterSettings extends Toggleable {
@@ -131,7 +132,8 @@ export class MainModel {
             Cost                : false,
             Accuracy            : false,
             Effect              : false,
-            EffectChance        : false
+            EffectChance        : false,
+            TypeEffectiveness   : false,
         }
 
         this.Starter = {

--- a/gui/src/MainModel.ts
+++ b/gui/src/MainModel.ts
@@ -99,6 +99,7 @@ export interface PatchSettings extends Toggleable {
     Softlock            : boolean
     UnlockAreas         : boolean
     UnrigSlots          : boolean
+    LearnMoveAndCommand : boolean
 }
 
 /* Public Constants */
@@ -194,7 +195,8 @@ export class MainModel {
             Gabu                : false,
             Softlock            : false,
             UnlockAreas         : false,
-            UnrigSlots          : false
+            UnrigSlots          : false,
+            LearnMoveAndCommand : false,
         }
 
         if( raw ) {

--- a/gui/src/constants.ts
+++ b/gui/src/constants.ts
@@ -470,4 +470,11 @@ export const patchElements: SectionElement<Main.PatchSettings>[] = [
     inputType: InputVariation.Checkbox,
     label: "Fix Softlocks",
     tooltip: `This fixes some movement related softlocks.` },
+  { attribute: "LearnMoveAndCommand",
+    inputType: InputVariation.Checkbox,
+    label: "Fix Brains Learning",
+    tooltip: 
+        `This patch disables the text for learning new commands, allowing you
+         to learn a command and a technique at the same session.
+         This mainly helps if you're doing Bonus Tries to obtain new moves.` },
 ]

--- a/gui/src/constants.ts
+++ b/gui/src/constants.ts
@@ -477,4 +477,15 @@ export const patchElements: SectionElement<Main.PatchSettings>[] = [
         `This patch disables the text for learning new commands, allowing you
          to learn a command and a technique at the same session.
          This mainly helps if you're doing Bonus Tries to obtain new moves.` },
+  { attribute: "FixDVChips",
+  inputType: InputVariation.Checkbox,
+  label: "Fix DV Chip descriptions",
+  tooltip: 
+      `Fixes DV Chip descriptions, to actually tell you what they do` },
+  { attribute: "HappyVending",
+    inputType: InputVariation.Checkbox,
+    label: "Happymushroom Vending",
+    tooltip: 
+        `Replaces Meat trade with a Happymushroom trade at the vending machine
+         at Dragon Eye Lake's top area.` },
 ]

--- a/gui/src/constants.ts
+++ b/gui/src/constants.ts
@@ -227,7 +227,12 @@ export const techDataElements: SectionElement<Main.TechSettings>[] = [
     tooltip: 
        `Randomize the chance of a status effect being inflicted for
         each tech.  Techs will be assigned a random value between 
-        1% and 70%.  This option is not affected by the mode.` }
+        1% and 70%.  This option is not affected by the mode.` },
+  { attribute: "TypeEffectiveness",
+    inputType: InputVariation.Checkbox,
+    label: "Type Effectiveness",
+    tooltip: `Randomizes the type effectiveness of different attributes.
+              The values will be between 2 and 20, as in vanilla.`}
 ]
 
 /* Evolution */


### PR DESCRIPTION
- potentially fixed softlock involving Nanimon in Leomon's Cave
- randomize type advantage table, closes #73 
- allow learning moves in training sessions that also unlock commands 
  - the patch simply removes the "unlocked command" text, since it's all flavor anyways
- increase step count for sliders from 20 to 100, to allow more fine grained control (especially with spawn chances)
- set spawnChance default value to 3
- increased console output size

___

- Fix DV Chip descriptions #70 
- Add patch to change Dragon Eye Lake vending machine into selling HappyMushroom to fix #42 
- print full error messages when they happen